### PR TITLE
Set the main field to the dist file

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"email": "support@creativebulma.net",
 		"url": "https://creativebulma.net"
 	},
-	"main": "./src/js/index.js",
+	"main": "./dist/js/bulma-tagsinput.js",
+	"module": "./src/js/index.js",
 	"style": "./dist/css/bulma-tagsinput.css",
 	"script": "./dist/js/bulma-tagsinput.js",
 	"sass": "./src/sass/index.sass",


### PR DESCRIPTION
The `main` field is set to the dist file, so it can be consumed using NodeJS, for example by jest. The newly added `module` field references the original source. This is consumed by module bundlers.