### PR TITLE
Fixed typo ligthen -> lighten

### DIFF
--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -117,7 +117,7 @@ $tagsinput-duplicate-animation: blinker .75s linear infinite !default
         cursor: not-allowed
 
         .tag
-            background-color: ligthen($input-disabled-background-color, 5%)
+            background-color: lighten($input-disabled-background-color, 5%)
             color: $input-disabled-color
             cursor: not-allowed
             .delete


### PR DESCRIPTION
There was a typo in the usage of the `lighten()` SASS function which was causing the styles to look broken when the input is disabled.